### PR TITLE
Update updog2vcf

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BIGr
 Title: Breeding Insight Genomics Functions for Polyploid and Diploid Species
-Version: 0.7.0
+Version: 0.8.0
 Authors@R: c(person(given='Alexander M.',
                     family='Sandercock',
                     email='sandercock.alex@gmail.com',

--- a/R/updog2vcf.R
+++ b/R/updog2vcf.R
@@ -126,9 +126,16 @@ updog2vcf <- function(multidog.object, output.file, updog_version = NULL, RefAlt
 
   #CHROM and POS from SNP ID
   new_df <- mout$snpdf %>%
-    separate(snp, into = c("CHROM", "POS"), sep = "_") %>%
+    extract(
+      snp,
+      into = c("CHROM", "POS"),
+      regex = "^(.*)_([^_]*)$"
+    ) %>%
+    mutate(
+      POS = sub("^0+", "", POS),
+      POS = if_else(POS == "", "0", POS)
+    ) %>%
     select(CHROM, POS)
-  new_df$POS <- sub("^0+", "", new_df$POS)
 
   #Make the VCF df
   vcf_df <- data.frame(


### PR DESCRIPTION
This pull request updates the `BIGr` package to version 0.8.0 and improves the extraction and formatting of chromosome and position information from SNP IDs in the `updog2vcf` function. The most important changes are:

**Version update:**

* Bumped the package version from 0.7.0 to 0.8.0 in the `DESCRIPTION` file to reflect new changes.

**VCF conversion improvements:**

* Updated the SNP ID parsing in `updog2vcf` (`R/updog2vcf.R`) to use `extract()` with a regex for more robust separation of chromosome and position, and added logic to remove leading zeros from the position and handle empty positions by setting them to "0".