### PR TITLE
Allow IUPAC codes on Match alleles

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BIGr
 Title: Breeding Insight Genomics Functions for Polyploid and Diploid
     Species
-Version: 0.8.1
+Version: 0.9.0
 Authors@R: c(
     person("Alexander M.", "Sandercock", , "sandercock.alex@gmail.com", role = c("cre", "aut")),
     person("Cristiane", "Taniguti", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# BIGr 0.9.0 (in progress)
+
+* `check_madc_sanity` updates: distinguish presence of IUPAC codes on REF/ALT (return logical variable IUPACcodes) from RefMatch/AltMatch/Others (returned logical variable IUPACcodes_MatchAlleles) and from Identical IUPAC code in identical positions in REF/ALT (returned logical variable IUPACcodes_IdenticalRefAlt)
+* Two new arguments to the `madc2vcf_all` function:
+    * `others_min_dist` (default 5bp)
+    * `others_max_close_snps` (default 3 SNPs)
+
+By default, “Other“ tags will be discarded if they have more than 3 SNPs with less than 5bp distance between them   
+* Adapt `madc2vcf_all` code to let pass identical IUPAC code in identical position in REF/ALT but ignore polymorphims in Match or Other alleles at the same position
+
+
 # BIGr 0.8.1
 
 - Updated madc2vcf_all and madc2vcf_targets. Before, it was possible for POS to be exported as scientific notation instead of integers, and for negative POS values to be present for off target SNPs. POS are corrected to be integers, and SNPs with a negative POS value are removed.

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
     * `others_min_dist` (default 5bp)
     * `others_max_close_snps` (default 3 SNPs)
 
-By default, “Other“ tags will be discarded if they have more than 3 SNPs with less than 5bp distance between them   
+* By default, `Other` tags will be discarded if they have more than 3 SNPs with less than 5bp distance between them   
 * Adapt `madc2vcf_all` code to let pass identical IUPAC code in identical position in REF/ALT but ignore polymorphims in Match or Other alleles at the same position
 * `madc2vcf_targets` and `madc2vcf_multi` will only throw an error if different IUPAC are present in REF/ALT sequences (IUPACcodes = TRUE)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# BIGr 0.9.0 (in progress)
+# BIGr 0.9.0
 
 * `check_madc_sanity` updates: distinguish presence of IUPAC codes on REF/ALT (return logical variable IUPACcodes) from RefMatch/AltMatch/Others (returned logical variable IUPACcodes_MatchAlleles) and from Identical IUPAC code in identical positions in REF/ALT (returned logical variable IUPACcodes_IdenticalRefAlt)
 * Two new arguments to the `madc2vcf_all` function:
@@ -7,6 +7,7 @@
 
 By default, “Other“ tags will be discarded if they have more than 3 SNPs with less than 5bp distance between them   
 * Adapt `madc2vcf_all` code to let pass identical IUPAC code in identical position in REF/ALT but ignore polymorphims in Match or Other alleles at the same position
+* `madc2vcf_targets` and `madc2vcf_multi` will only throw an error if different IUPAC are present in REF/ALT sequences (IUPACcodes = TRUE)
 
 
 # BIGr 0.8.1

--- a/R/check_madc_sanity.R
+++ b/R/check_madc_sanity.R
@@ -129,50 +129,50 @@ check_madc_sanity <- function(report) {
     # Get Ref and Alt sequences
     refs <- subset(report, grepl("Ref_", AlleleID), select = c(CloneID, AlleleID, AlleleSequence))
     alts <- subset(report, grepl("Alt_", AlleleID), select = c(CloneID, AlleleID, AlleleSequence))
-    
+
     # Identify sequences with IUPAC codes
     refs_with_iupac <- refs[grepl("[^ATCG-]", refs$AlleleSequence, ignore.case = TRUE), ]
     alts_with_iupac <- alts[grepl("[^ATCG-]", alts$AlleleSequence, ignore.case = TRUE), ]
-    
+
     # Merge Ref and Alt by CloneID to compare sequences
-    merged_iupac <- merge(refs_with_iupac, alts_with_iupac, by = "CloneID", 
+    merged_iupac <- merge(refs_with_iupac, alts_with_iupac, by = "CloneID",
                           suffixes = c("_ref", "_alt"), all = FALSE)
-    
+
     # Check if IUPAC codes are at the same positions in both sequences
     if (nrow(merged_iupac) > 0) {
       identical_iupac_positions <- vapply(seq_len(nrow(merged_iupac)), function(i) {
         ref_seq <- toupper(merged_iupac$AlleleSequence_ref[i])
         alt_seq <- toupper(merged_iupac$AlleleSequence_alt[i])
-        
+
         # Split sequences into characters
         ref_chars <- strsplit(ref_seq, "")[[1]]
         alt_chars <- strsplit(alt_seq, "")[[1]]
-        
+
         # Check if same length
         if (length(ref_chars) != length(alt_chars)) return(FALSE)
-        
+
         # Check if IUPAC codes are at the same positions
         ref_is_iupac <- !ref_chars %in% c("A", "T", "C", "G", "-")
         alt_is_iupac <- !alt_chars %in% c("A", "T", "C", "G", "-")
-        
+
         # IUPAC codes must be at exactly the same positions
         all(ref_is_iupac == alt_is_iupac)
       }, logical(1))
-      
+
       iupac_identical_clone_ids <- merged_iupac$CloneID[identical_iupac_positions]
     } else {
       iupac_identical_clone_ids <- character(0)
     }
-    
+
     # Get all CloneIDs with IUPAC in either Ref or Alt
     all_iupac_clones <- unique(c(refs_with_iupac$CloneID, alts_with_iupac$CloneID))
     # IUPAC codes that differ between Ref and Alt (or present in only one)
     differing_iupac_clones <- setdiff(all_iupac_clones, iupac_identical_clone_ids)
-    
+
     # Only flag as TRUE if there are IUPAC codes that differ
     checks["IUPACcodes"] <- length(differing_iupac_clones) > 0
     checks["IUPACcodes_IdenticalRefAlt"] <- length(iupac_identical_clone_ids) > 0
-    
+
     # Check for IUPAC codes in RefMatch_ and AltMatch_ alleles
     ref_alt_match_rows <- grepl("RefMatch_|AltMatch_", report$AlleleID)
     iu_match <- grepl("[^ATCG-]", report$AlleleSequence[ref_alt_match_rows], ignore.case = TRUE)
@@ -263,7 +263,7 @@ check_madc_sanity <- function(report) {
                                   "MADC not processed by HapApp")
   messages[["IUPACcodes"]] <- c("IUPAC (non-ATCG) codes found in Ref_/Alt_ AlleleSequence that differ between alleles or are present in only one. These codes are not currently supported by BIGr/BIGapp",
                                 "No differing IUPAC (non-ATCG) codes found in Ref_/Alt_ AlleleSequence")
-  messages[["IUPACcodes_IdenticalRefAlt"]] <- c("IUPAC (non-ATCG) codes found at identical positions in Ref and Alt AlleleSequence. These codes will be handled during VCF conversion",
+  messages[["IUPACcodes_IdenticalRefAlt"]] <- c("Identical IUPAC (non-ATCG) codes found at identical positions in Ref and Alt AlleleSequence. These codes will be handled during VCF conversion",
                                                  "No IUPAC (non-ATCG) codes found at identical positions in Ref and Alt AlleleSequence")
   messages[["LowerCase"]] <- c("Lowercase bases found in AlleleSequence",
                                "No lowercase bases found in AlleleSequence")

--- a/R/check_madc_sanity.R
+++ b/R/check_madc_sanity.R
@@ -1,11 +1,11 @@
 #' Run basic sanity checks on a MADC-style allele report
 #'
 #' @description
-#' Performs nine quick validations on an allele report:
+#' Performs eleven quick validations on an allele report:
 #' 1) **Columns** - required columns are present (`CloneID`, `AlleleID`, `AlleleSequence`);
 #' 2) **FixAlleleIDs** - first column's first up-to-6 rows are not all blank or `"*"`
 #'    *and* both `_0001` and `_0002` appear in `AlleleID`;
-#' 3) **IUPACcodes** - presence of non-ATCG characters in `AlleleSequence`;
+#' 3) **IUPACcodes** - presence of non-ATCG characters in `AlleleSequence` for Ref_/Alt_ alleles;
 #' 4) **LowerCase** - presence of lowercase a/t/c/g in `AlleleSequence`;
 #' 5) **Indels** - reference/alternate allele lengths differ for the same `CloneID`,
 #'    or a `"-"` character is present in `AlleleSequence`;
@@ -14,7 +14,8 @@
 #' 7) **allNAcol** - at least one column contains only `NA` or empty values;
 #' 8) **allNArow** - at least one row contains only `NA` or empty values;
 #' 9) **RefAltSeqs** - every `CloneID` has at least one `Ref` and one `Alt` allele row;
-#' 10) **OtherAlleles** - presence of alleles where the target locus differs from both the Ref and Alt in `AlleleSequence`.
+#' 10) **OtherAlleles** - presence of alleles where the target locus differs from both the Ref and Alt in `AlleleSequence`;
+#' 11) **IUPACcodes_MatchAlleles** - presence of non-ATCG characters in `AlleleSequence` for RefMatch_/AltMatch_ alleles.
 #'
 #' @param report A `data.frame` with at least the columns
 #'   `CloneID`, `AlleleID`, and `AlleleSequence`. The first column is also
@@ -30,6 +31,8 @@
 #'   `_0001`/`_0002` suffixes).
 #' - **IUPAC check:** Flags any character outside `A`, `T`, `C`, `G` and `"-"`
 #'   (case-insensitive), which includes ambiguity codes (`N`, `R`, `Y`, etc.).
+#'   Checked separately for Ref_/Alt_ alleles (IUPACcodes) and RefMatch_/AltMatch_
+#'   alleles (IUPACcodes_MatchAlleles).
 #' - **Indels:** Rows are split by `AlleleID` containing `"Ref_0001"` vs
 #'   `"Alt_0002"`, merged by `CloneID`, and flagged as indels if either (a) the
 #'   lengths of `AlleleSequence` differ, (b) the sequences have the same length
@@ -53,9 +56,10 @@
 #'
 #' @return A named list with five elements:
 #' \describe{
-#'   \item{checks}{Named logical vector with nine entries:
+#'   \item{checks}{Named logical vector with eleven entries:
 #'     `Columns`, `FixAlleleIDs`, `IUPACcodes`, `LowerCase`, `Indels`,
-#'     `ChromPos`, `allNAcol`, `allNArow`, `RefAltSeqs`.
+#'     `ChromPos`, `allNAcol`, `allNArow`, `RefAltSeqs`, `OtherAlleles`,
+#'     `IUPACcodes_MatchAlleles`.
 #'     `TRUE` means the condition was detected (or passed for `Columns`,
 #'     `FixAlleleIDs`, `ChromPos`, and `RefAltSeqs`); `NA` means the check
 #'     was skipped.}
@@ -78,9 +82,11 @@ check_madc_sanity <- function(report) {
 
   # Initialize
   checks <- c(Columns = NA, FixAlleleIDs = NA, IUPACcodes = NA, LowerCase = NA, Indels = NA,
-              ChromPos = NA, allNAcol = NA, allNArow = NA, RefAltSeqs = NA, OtherAlleles = NA)
+              ChromPos = NA, allNAcol = NA, allNArow = NA, RefAltSeqs = NA, OtherAlleles = NA,
+              IUPACcodes_MatchAlleles = NA)
   messages <-  list(Columns = NA, FixAlleleIDs = NA, IUPACcodes = NA, LowerCase = NA, Indels = NA,
-                    ChromPos = NA, allNAcol = NA, allNArow = NA, RefAltSeqs = NA, OtherAlleles = NA)
+                    ChromPos = NA, allNAcol = NA, allNArow = NA, RefAltSeqs = NA, OtherAlleles = NA,
+                    IUPACcodes_MatchAlleles = NA)
 
   # ---- FixAlleleIDs ----
   # Check if first up-to-6 entries in the *first column* are all "" or "*"
@@ -104,8 +110,15 @@ check_madc_sanity <- function(report) {
 
   if(checks[["Columns"]]){
     # ---- IUPACcodes ----
-    iu <- grepl("[^ATCG-]", report$AlleleSequence, ignore.case = TRUE)
-    checks["IUPACcodes"] <- any(iu, na.rm = TRUE)
+    # Check for IUPAC codes in Ref_ and Alt_ alleles
+    ref_alt_rows <- grepl("Ref_|Alt_", report$AlleleID)
+    iu_ref_alt <- grepl("[^ATCG-]", report$AlleleSequence[ref_alt_rows], ignore.case = TRUE)
+    checks["IUPACcodes"] <- any(iu_ref_alt, na.rm = TRUE)
+    
+    # Check for IUPAC codes in RefMatch_ and AltMatch_ alleles
+    ref_alt_match_rows <- grepl("RefMatch_|AltMatch_", report$AlleleID)
+    iu_match <- grepl("[^ATCG-]", report$AlleleSequence[ref_alt_match_rows], ignore.case = TRUE)
+    checks["IUPACcodes_MatchAlleles"] <- any(iu_match, na.rm = TRUE)
 
     # ---- LowerCase ----
     lc <- grepl("[atcg]", report$AlleleSequence)
@@ -189,8 +202,8 @@ check_madc_sanity <- function(report) {
                              "One or more required columns missing. Verify if your file has columns: CloneID, AlleleID, AlleleSequence")
   messages[["FixAlleleIDs"]] <- c("Fixed Allele IDs look good",
                                   "MADC not processed by HapApp")
-  messages[["IUPACcodes"]] <- c("IUPAC (non-ATCG) codes found in AlleleSequence. This codes are not currently supported by BIGr/BIGapp. Run HapApp to replace them",
-                                "No IUPAC (non-ATCG) codes found in AlleleSequence")
+  messages[["IUPACcodes"]] <- c("IUPAC (non-ATCG) codes found in Ref_/Alt_ AlleleSequence. This codes are not currently supported by BIGr/BIGapp. Run HapApp to replace them",
+                                "No IUPAC (non-ATCG) codes found in Ref_/Alt_ AlleleSequence")
   messages[["LowerCase"]] <- c("Lowercase bases found in AlleleSequence",
                                "No lowercase bases found in AlleleSequence")
   messages[["Indels"]] <- c(paste("Indels found (ref/alt lengths differ or >1 mismatch between same-length sequences) for the CloneIDs:",paste(indels, collapse = " ")),
@@ -207,6 +220,8 @@ check_madc_sanity <- function(report) {
                                        "Missing Alt: ", paste(missAlt, collapse = " "), "."))
   messages[["OtherAlleles"]] <- c("Alleles other than Ref and Alt were found in AlleleID",
                                   "No alleles other than Ref and Alt found in AlleleID")
+  messages[["IUPACcodes_MatchAlleles"]] <- c("IUPAC (non-ATCG) codes found in RefMatch/AltMatch AlleleSequence. This codes are not currently supported by BIGr/BIGapp they will be ignored in the conversion to VCF",
+                                              "No IUPAC (non-ATCG) codes found in RefMatch/AltMatch AlleleSequence")
 
   list(checks = checks, messages = messages, indel_clone_ids = indels,
        missRef = missRef, missAlt = missAlt)

--- a/R/check_madc_sanity.R
+++ b/R/check_madc_sanity.R
@@ -1,21 +1,24 @@
 #' Run basic sanity checks on a MADC-style allele report
 #'
 #' @description
-#' Performs eleven quick validations on an allele report:
+#' Performs twelve quick validations on an allele report:
 #' 1) **Columns** - required columns are present (`CloneID`, `AlleleID`, `AlleleSequence`);
 #' 2) **FixAlleleIDs** - first column's first up-to-6 rows are not all blank or `"*"`
 #'    *and* both `_0001` and `_0002` appear in `AlleleID`;
-#' 3) **IUPACcodes** - presence of non-ATCG characters in `AlleleSequence` for Ref_/Alt_ alleles;
-#' 4) **LowerCase** - presence of lowercase a/t/c/g in `AlleleSequence`;
-#' 5) **Indels** - reference/alternate allele lengths differ for the same `CloneID`,
+#' 3) **IUPACcodes** - presence of non-ATCG characters in Ref_/Alt_ `AlleleSequence`
+#'    that differ in position between Ref and Alt, or are present in only one;
+#' 4) **IUPACcodes_IdenticalRefAlt** - presence of Ref_/Alt_ pairs that share IUPAC codes
+#'    at the same positions in their sequences;
+#' 5) **LowerCase** - presence of lowercase a/t/c/g in `AlleleSequence`;
+#' 6) **Indels** - reference/alternate allele lengths differ for the same `CloneID`,
 #'    or a `"-"` character is present in `AlleleSequence`;
-#' 6) **ChromPos** - all `CloneID` values follow the `Chr_Position` format
+#' 7) **ChromPos** - all `CloneID` values follow the `Chr_Position` format
 #'    (prefix matches `"chr"` case-insensitively, suffix is a positive integer);
-#' 7) **allNAcol** - at least one column contains only `NA` or empty values;
-#' 8) **allNArow** - at least one row contains only `NA` or empty values;
-#' 9) **RefAltSeqs** - every `CloneID` has at least one `Ref` and one `Alt` allele row;
-#' 10) **OtherAlleles** - presence of alleles where the target locus differs from both the Ref and Alt in `AlleleSequence`;
-#' 11) **IUPACcodes_MatchAlleles** - presence of non-ATCG characters in `AlleleSequence` for RefMatch_/AltMatch_ alleles.
+#' 8) **allNAcol** - at least one column contains only `NA` or empty values;
+#' 9) **allNArow** - at least one row contains only `NA` or empty values;
+#' 10) **RefAltSeqs** - every `CloneID` has at least one `Ref` and one `Alt` allele row;
+#' 11) **OtherAlleles** - presence of alleles where the target locus differs from both the Ref and Alt in `AlleleSequence`;
+#' 12) **IUPACcodes_MatchAlleles** - presence of non-ATCG characters in `AlleleSequence` for RefMatch_/AltMatch_ alleles.
 #'
 #' @param report A `data.frame` with at least the columns
 #'   `CloneID`, `AlleleID`, and `AlleleSequence`. The first column is also
@@ -31,8 +34,13 @@
 #'   `_0001`/`_0002` suffixes).
 #' - **IUPAC check:** Flags any character outside `A`, `T`, `C`, `G` and `"-"`
 #'   (case-insensitive), which includes ambiguity codes (`N`, `R`, `Y`, etc.).
-#'   Checked separately for Ref_/Alt_ alleles (IUPACcodes) and RefMatch_/AltMatch_
-#'   alleles (IUPACcodes_MatchAlleles).
+#'   For Ref_/Alt_ alleles, two checks are performed: `IUPACcodes` is `TRUE` when
+#'   any CloneID has IUPAC codes at different positions between Ref and Alt, or
+#'   IUPAC is present in only one of them. `IUPACcodes_IdenticalRefAlt` is `TRUE`
+#'   when any CloneID has Ref and Alt with IUPAC codes at exactly the same positions
+#'   (non-IUPAC bases may still differ). Those CloneIDs are stored in
+#'   `iupac_identical_clone_ids`. RefMatch_/AltMatch_ alleles are checked
+#'   separately via `IUPACcodes_MatchAlleles`.
 #' - **Indels:** Rows are split by `AlleleID` containing `"Ref_0001"` vs
 #'   `"Alt_0002"`, merged by `CloneID`, and flagged as indels if either (a) the
 #'   lengths of `AlleleSequence` differ, (b) the sequences have the same length
@@ -54,12 +62,12 @@
 #'   `FixAlleleIDs` are evaluated; all other checks remain `NA` and
 #'   `indel_clone_ids`, `missRef`, and `missAlt` are returned as `NULL`.
 #'
-#' @return A named list with five elements:
+#' @return A named list with six elements:
 #' \describe{
-#'   \item{checks}{Named logical vector with eleven entries:
-#'     `Columns`, `FixAlleleIDs`, `IUPACcodes`, `LowerCase`, `Indels`,
-#'     `ChromPos`, `allNAcol`, `allNArow`, `RefAltSeqs`, `OtherAlleles`,
-#'     `IUPACcodes_MatchAlleles`.
+#'   \item{checks}{Named logical vector with twelve entries:
+#'     `Columns`, `FixAlleleIDs`, `IUPACcodes`, `IUPACcodes_IdenticalRefAlt`,
+#'     `LowerCase`, `Indels`, `ChromPos`, `allNAcol`, `allNArow`, `RefAltSeqs`,
+#'     `OtherAlleles`, `IUPACcodes_MatchAlleles`.
 #'     `TRUE` means the condition was detected (or passed for `Columns`,
 #'     `FixAlleleIDs`, `ChromPos`, and `RefAltSeqs`); `NA` means the check
 #'     was skipped.}
@@ -69,6 +77,11 @@
 #'   \item{indel_clone_ids}{Character vector of `CloneID`s where ref/alt
 #'     lengths differ. Returns `character(0)` if none are found, or `NULL`
 #'     when required columns are missing.}
+#'   \item{iupac_identical_clone_ids}{Character vector of `CloneID`s where
+#'     Ref and Alt alleles have IUPAC codes at the same positions in their
+#'     sequences (the sequences may differ at standard ATCG positions). Returns
+#'     `character(0)` if none are found, or `NULL` when required columns are
+#'     missing.}
 #'   \item{missRef}{Character vector of `CloneID`s that have no `Ref` allele
 #'     row. Returns `character(0)` if all `CloneID`s have a `Ref` row, or
 #'     `NULL` when required columns are missing.}
@@ -81,10 +94,12 @@
 check_madc_sanity <- function(report) {
 
   # Initialize
-  checks <- c(Columns = NA, FixAlleleIDs = NA, IUPACcodes = NA, LowerCase = NA, Indels = NA,
+  checks <- c(Columns = NA, FixAlleleIDs = NA, IUPACcodes = NA, IUPACcodes_IdenticalRefAlt = NA,
+              LowerCase = NA, Indels = NA,
               ChromPos = NA, allNAcol = NA, allNArow = NA, RefAltSeqs = NA, OtherAlleles = NA,
               IUPACcodes_MatchAlleles = NA)
-  messages <-  list(Columns = NA, FixAlleleIDs = NA, IUPACcodes = NA, LowerCase = NA, Indels = NA,
+  messages <-  list(Columns = NA, FixAlleleIDs = NA, IUPACcodes = NA, IUPACcodes_IdenticalRefAlt = NA,
+                    LowerCase = NA, Indels = NA,
                     ChromPos = NA, allNAcol = NA, allNArow = NA, RefAltSeqs = NA, OtherAlleles = NA,
                     IUPACcodes_MatchAlleles = NA)
 
@@ -111,9 +126,52 @@ check_madc_sanity <- function(report) {
   if(checks[["Columns"]]){
     # ---- IUPACcodes ----
     # Check for IUPAC codes in Ref_ and Alt_ alleles
-    ref_alt_rows <- grepl("Ref_|Alt_", report$AlleleID)
-    iu_ref_alt <- grepl("[^ATCG-]", report$AlleleSequence[ref_alt_rows], ignore.case = TRUE)
-    checks["IUPACcodes"] <- any(iu_ref_alt, na.rm = TRUE)
+    # Get Ref and Alt sequences
+    refs <- subset(report, grepl("Ref_", AlleleID), select = c(CloneID, AlleleID, AlleleSequence))
+    alts <- subset(report, grepl("Alt_", AlleleID), select = c(CloneID, AlleleID, AlleleSequence))
+    
+    # Identify sequences with IUPAC codes
+    refs_with_iupac <- refs[grepl("[^ATCG-]", refs$AlleleSequence, ignore.case = TRUE), ]
+    alts_with_iupac <- alts[grepl("[^ATCG-]", alts$AlleleSequence, ignore.case = TRUE), ]
+    
+    # Merge Ref and Alt by CloneID to compare sequences
+    merged_iupac <- merge(refs_with_iupac, alts_with_iupac, by = "CloneID", 
+                          suffixes = c("_ref", "_alt"), all = FALSE)
+    
+    # Check if IUPAC codes are at the same positions in both sequences
+    if (nrow(merged_iupac) > 0) {
+      identical_iupac_positions <- vapply(seq_len(nrow(merged_iupac)), function(i) {
+        ref_seq <- toupper(merged_iupac$AlleleSequence_ref[i])
+        alt_seq <- toupper(merged_iupac$AlleleSequence_alt[i])
+        
+        # Split sequences into characters
+        ref_chars <- strsplit(ref_seq, "")[[1]]
+        alt_chars <- strsplit(alt_seq, "")[[1]]
+        
+        # Check if same length
+        if (length(ref_chars) != length(alt_chars)) return(FALSE)
+        
+        # Check if IUPAC codes are at the same positions
+        ref_is_iupac <- !ref_chars %in% c("A", "T", "C", "G", "-")
+        alt_is_iupac <- !alt_chars %in% c("A", "T", "C", "G", "-")
+        
+        # IUPAC codes must be at exactly the same positions
+        all(ref_is_iupac == alt_is_iupac)
+      }, logical(1))
+      
+      iupac_identical_clone_ids <- merged_iupac$CloneID[identical_iupac_positions]
+    } else {
+      iupac_identical_clone_ids <- character(0)
+    }
+    
+    # Get all CloneIDs with IUPAC in either Ref or Alt
+    all_iupac_clones <- unique(c(refs_with_iupac$CloneID, alts_with_iupac$CloneID))
+    # IUPAC codes that differ between Ref and Alt (or present in only one)
+    differing_iupac_clones <- setdiff(all_iupac_clones, iupac_identical_clone_ids)
+    
+    # Only flag as TRUE if there are IUPAC codes that differ
+    checks["IUPACcodes"] <- length(differing_iupac_clones) > 0
+    checks["IUPACcodes_IdenticalRefAlt"] <- length(iupac_identical_clone_ids) > 0
     
     # Check for IUPAC codes in RefMatch_ and AltMatch_ alleles
     ref_alt_match_rows <- grepl("RefMatch_|AltMatch_", report$AlleleID)
@@ -194,6 +252,7 @@ check_madc_sanity <- function(report) {
 
   } else {
     indels  <- NULL
+    iupac_identical_clone_ids <- NULL
     missRef <- NULL
     missAlt <- NULL
   }
@@ -202,8 +261,10 @@ check_madc_sanity <- function(report) {
                              "One or more required columns missing. Verify if your file has columns: CloneID, AlleleID, AlleleSequence")
   messages[["FixAlleleIDs"]] <- c("Fixed Allele IDs look good",
                                   "MADC not processed by HapApp")
-  messages[["IUPACcodes"]] <- c("IUPAC (non-ATCG) codes found in Ref_/Alt_ AlleleSequence. This codes are not currently supported by BIGr/BIGapp. Run HapApp to replace them",
-                                "No IUPAC (non-ATCG) codes found in Ref_/Alt_ AlleleSequence")
+  messages[["IUPACcodes"]] <- c("IUPAC (non-ATCG) codes found in Ref_/Alt_ AlleleSequence that differ between alleles or are present in only one. These codes are not currently supported by BIGr/BIGapp",
+                                "No differing IUPAC (non-ATCG) codes found in Ref_/Alt_ AlleleSequence")
+  messages[["IUPACcodes_IdenticalRefAlt"]] <- c("IUPAC (non-ATCG) codes found at identical positions in Ref and Alt AlleleSequence. These codes will be handled during VCF conversion",
+                                                 "No IUPAC (non-ATCG) codes found at identical positions in Ref and Alt AlleleSequence")
   messages[["LowerCase"]] <- c("Lowercase bases found in AlleleSequence",
                                "No lowercase bases found in AlleleSequence")
   messages[["Indels"]] <- c(paste("Indels found (ref/alt lengths differ or >1 mismatch between same-length sequences) for the CloneIDs:",paste(indels, collapse = " ")),
@@ -224,6 +285,7 @@ check_madc_sanity <- function(report) {
                                               "No IUPAC (non-ATCG) codes found in RefMatch/AltMatch AlleleSequence")
 
   list(checks = checks, messages = messages, indel_clone_ids = indels,
+       iupac_identical_clone_ids = iupac_identical_clone_ids,
        missRef = missRef, missAlt = missAlt)
 }
 

--- a/R/check_madc_sanity.R
+++ b/R/check_madc_sanity.R
@@ -18,7 +18,7 @@
 #' 9) **allNArow** - at least one row contains only `NA` or empty values;
 #' 10) **RefAltSeqs** - every `CloneID` has at least one `Ref` and one `Alt` allele row;
 #' 11) **OtherAlleles** - presence of alleles where the target locus differs from both the Ref and Alt in `AlleleSequence`;
-#' 12) **IUPACcodes_MatchAlleles** - presence of non-ATCG characters in `AlleleSequence` for RefMatch_/AltMatch_ alleles.
+#' 12) **IUPACcodes_MatchAlleles** - presence of non-ATCG characters in `AlleleSequence` for RefMatch_/AltMatch_/Other alleles.
 #'
 #' @param report A `data.frame` with at least the columns
 #'   `CloneID`, `AlleleID`, and `AlleleSequence`. The first column is also
@@ -39,7 +39,7 @@
 #'   IUPAC is present in only one of them. `IUPACcodes_IdenticalRefAlt` is `TRUE`
 #'   when any CloneID has Ref and Alt with IUPAC codes at exactly the same positions
 #'   (non-IUPAC bases may still differ). Those CloneIDs are stored in
-#'   `iupac_identical_clone_ids`. RefMatch_/AltMatch_ alleles are checked
+#'   `iupac_identical_clone_ids`. RefMatch_/AltMatch_/Other alleles are checked
 #'   separately via `IUPACcodes_MatchAlleles`.
 #' - **Indels:** Rows are split by `AlleleID` containing `"Ref_0001"` vs
 #'   `"Alt_0002"`, merged by `CloneID`, and flagged as indels if either (a) the
@@ -155,11 +155,12 @@ check_madc_sanity <- function(report) {
         ref_is_iupac <- !ref_chars %in% c("A", "T", "C", "G", "-")
         alt_is_iupac <- !alt_chars %in% c("A", "T", "C", "G", "-")
 
-        # IUPAC codes must be at exactly the same positions
-        all(ref_is_iupac == alt_is_iupac)
+        # IUPAC codes must be at exactly the same positions AND be the same codes
+        all(ref_is_iupac == alt_is_iupac) &&
+          all(ref_chars[ref_is_iupac] == alt_chars[alt_is_iupac])
       }, logical(1))
 
-      iupac_identical_clone_ids <- merged_iupac$CloneID[identical_iupac_positions]
+      iupac_identical_clone_ids <- unique(merged_iupac$CloneID[identical_iupac_positions])
     } else {
       iupac_identical_clone_ids <- character(0)
     }
@@ -173,8 +174,8 @@ check_madc_sanity <- function(report) {
     checks["IUPACcodes"] <- length(differing_iupac_clones) > 0
     checks["IUPACcodes_IdenticalRefAlt"] <- length(iupac_identical_clone_ids) > 0
 
-    # Check for IUPAC codes in RefMatch_ and AltMatch_ alleles
-    ref_alt_match_rows <- grepl("RefMatch_|AltMatch_", report$AlleleID)
+    # Check for IUPAC codes in RefMatch_, AltMatch_, and Other alleles
+    ref_alt_match_rows <- grepl("RefMatch_|AltMatch_|[|]Other", report$AlleleID)
     iu_match <- grepl("[^ATCG-]", report$AlleleSequence[ref_alt_match_rows], ignore.case = TRUE)
     checks["IUPACcodes_MatchAlleles"] <- any(iu_match, na.rm = TRUE)
 
@@ -281,8 +282,8 @@ check_madc_sanity <- function(report) {
                                        "Missing Alt: ", paste(missAlt, collapse = " "), "."))
   messages[["OtherAlleles"]] <- c("Alleles other than Ref and Alt were found in AlleleID",
                                   "No alleles other than Ref and Alt found in AlleleID")
-  messages[["IUPACcodes_MatchAlleles"]] <- c("IUPAC (non-ATCG) codes found in RefMatch/AltMatch AlleleSequence. This codes are not currently supported by BIGr/BIGapp they will be ignored in the conversion to VCF",
-                                              "No IUPAC (non-ATCG) codes found in RefMatch/AltMatch AlleleSequence")
+  messages[["IUPACcodes_MatchAlleles"]] <- c("IUPAC (non-ATCG) codes found in RefMatch/AltMatch/Other AlleleSequence. This codes are not currently supported by BIGr/BIGapp they will be ignored in the conversion to VCF",
+                                              "No IUPAC (non-ATCG) codes found in RefMatch/AltMatch/Other AlleleSequence")
 
   list(checks = checks, messages = messages, indel_clone_ids = indels,
        iupac_identical_clone_ids = iupac_identical_clone_ids,

--- a/R/check_madc_sanity.R
+++ b/R/check_madc_sanity.R
@@ -282,7 +282,7 @@ check_madc_sanity <- function(report) {
                                        "Missing Alt: ", paste(missAlt, collapse = " "), "."))
   messages[["OtherAlleles"]] <- c("Alleles other than Ref and Alt were found in AlleleID",
                                   "No alleles other than Ref and Alt found in AlleleID")
-  messages[["IUPACcodes_MatchAlleles"]] <- c("IUPAC (non-ATCG) codes found in RefMatch/AltMatch/Other AlleleSequence. This codes are not currently supported by BIGr/BIGapp they will be ignored in the conversion to VCF",
+  messages[["IUPACcodes_MatchAlleles"]] <- c("IUPAC (non-ATCG) codes found in RefMatch/AltMatch/Other AlleleSequence. These codes are not currently supported by BIGr/BIGapp they will be ignored in the conversion to VCF",
                                               "No IUPAC (non-ATCG) codes found in RefMatch/AltMatch/Other AlleleSequence")
 
   list(checks = checks, messages = messages, indel_clone_ids = indels,

--- a/R/madc2vcf_all.R
+++ b/R/madc2vcf_all.R
@@ -13,8 +13,10 @@
 #' @param out_vcf A string specifying the name of the output VCF file. If the file extension is not `.vcf`, it will be appended automatically.
 #' @param markers_info A string specifying the path to a CSV file with marker information (CloneID/BI_markerID, Chr, Pos, Ref, Alt, Type, Indel_pos columns as needed).
 #' @param add_others A logical value. If TRUE, alleles labeled "Other" in the MADC file are included in off-target SNP extraction. Default is TRUE.
-#' @param others_max_snps An integer or NULL. If not NULL, Other alleles with more than this many SNP differences versus the Ref sequence (as detected by pairwise alignment) are discarded. Default is NULL (no limit).
+#' @param others_max_snps An integer or NULL. If not NULL, Other alleles with more than this many SNP differences versus the Ref sequence (as detected by pairwise alignment) are discarded. Default is 5.
 #' @param others_rm_with_indels A logical value. If TRUE, Other alleles that contain insertions or deletions relative to the Ref sequence (as detected by pairwise alignment) are discarded. Default is TRUE.
+#' @param others_min_dist An integer specifying the minimum distance (in base pairs) between SNPs in Other alleles. Default is 5.
+#' @param others_max_close_snps An integer or NULL. If not NULL, Other alleles with more than this many SNPs that are closer than `others_min_dist` base pairs to each other are discarded. Default is 3.
 #' @param verbose A logical value indicating whether to print metrics and progress to the console. Default is TRUE.
 #'
 #' @return This function does not return an R object. It writes the processed VCF file v4.3 to the specified `out_vcf` path.
@@ -80,7 +82,15 @@ madc2vcf_all <- function(madc,
                          add_others = TRUE,
                          others_max_snps = 5,
                          others_rm_with_indels = TRUE,
+                         others_min_dist = 5,
+                         others_max_close_snps = 3,
                          verbose = TRUE){
+
+
+  # Check that file path arguments are strings before any processing
+  if(!is.character(madc) || length(madc) != 1L) stop("madc should be a single string specifying the path or URL to the MADC file.")
+  if(!is.character(botloci_file) || length(botloci_file) != 1L) stop("botloci_file should be a single string specifying the path or URL to the botloci file.")
+  if(!is.null(hap_seq_file) && (!is.character(hap_seq_file) || length(hap_seq_file) != 1L)) stop("hap_seq_file should be a single string specifying the path to the haplotype database fasta file.")
 
   vmsg("Running BIGr madc2vcf_all", verbose = verbose, level = 0, type = ">>")
   vmsg("madc              : %s", verbose = verbose, level = 1, type = ">>", madc)
@@ -158,7 +168,7 @@ madc2vcf_all <- function(madc,
   # Check whether markers_info is present and contains Ref + Alt columns
   if(!is.null(markers_info)) {
     mi_df <- read.csv(markers_info)
-    id_cols <- intersect(c("CloneID", "BI_markerID"), colnames(mi_df))
+    id_cols <- intersect(c("CloneID", "BI_markerID","Marker_ID"), colnames(mi_df))
     if(!length(id_cols)) {
       stop("markers_info must contain a marker ID column named either 'CloneID' or 'BI_markerID'.")
     }
@@ -171,8 +181,8 @@ madc2vcf_all <- function(madc,
     id_col <- id_cols[which.max(match_n)]
     if(id_col != "CloneID" || !"CloneID" %in% colnames(mi_df)) {
       mi_df$CloneID <- mi_df[[id_col]]
-      if(id_col == "BI_markerID") {
-        vmsg("markers_info: 'BI_markerID' column copied to 'CloneID' for internal use", verbose = verbose, level = 1)
+      if(id_col == "BI_markerID" | id_col == "Marker_ID") {
+        vmsg("markers_info: 'BI_markerID' or 'Marker_ID' column copied to 'CloneID' for internal use", verbose = verbose, level = 1)
       }
     }
     # Validate CloneID values
@@ -257,6 +267,8 @@ madc2vcf_all <- function(madc,
                                               add_others = add_others,
                                               others_max_snps = others_max_snps,
                                               others_rm_with_indels = others_rm_with_indels,
+                                              others_min_dist = others_min_dist,
+                                              others_max_close_snps = others_max_close_snps,
                                               verbose = verbose)
 
   vmsg("All information gathered!", verbose = verbose, level = 0, type = ">>")
@@ -305,9 +317,19 @@ madc2vcf_all <- function(madc,
 #' @import parallel
 #'
 #' @noRd
-loop_though_dartag_report <- function(report, botloci, hap_seq, n.cores=1, alignment_score_thr=40,
-                                      checks = NULL, mi_df = NULL, pad_width = NULL,
-                                      add_others = TRUE, others_max_snps = NULL, others_rm_with_indels = TRUE,
+loop_though_dartag_report <- function(report,
+                                      botloci,
+                                      hap_seq,
+                                      n.cores=1,
+                                      alignment_score_thr=40,
+                                      checks = NULL,
+                                      mi_df = NULL,
+                                      pad_width = NULL,
+                                      add_others = TRUE,
+                                      others_max_snps = 5,
+                                      others_rm_with_indels = TRUE,
+                                      others_min_dist = 5,
+                                      others_max_close_snps = 3,
                                       verbose = TRUE){
 
   if(!is.null(hap_seq) & (is.null(checks) | !isTRUE(checks$checks["RefAltSeqs"]))){
@@ -351,10 +373,17 @@ loop_though_dartag_report <- function(report, botloci, hap_seq, n.cores=1, align
   vmsg("Pairwise alignments of sequences to recover SNP position, reference and alternative bases...", verbose = verbose, level = 0)
   clust <- makeCluster(n.cores)
   #clusterExport(clust, c("botloci", "compare", "nucleotideSubstitutionMatrix", "pairwiseAlignment", "DNAString", "reverseComplement"))
-  #clusterExport(clust, c("botloci", "alignment_score_thr", "mi_df", "add_others", "others_max_snps", "others_rm_with_indels"))
-  compare_results <- parLapply(clust, updated_by_cloneID, function(x) compare(x, botloci, alignment_score_thr, mi_df,
-                                                                              add_others = add_others, others_max_snps = others_max_snps,
-                                                                              others_rm_with_indels = others_rm_with_indels, verbose = FALSE))
+  #clusterExport(clust, c("botloci", "alignment_score_thr", "mi_df", "add_others", "others_max_snps", "others_rm_with_indels", "others_min_dist", "others_max_close_snps"))
+  compare_results <- parLapply(clust, updated_by_cloneID, function(x) compare(x,
+                                                                              botloci,
+                                                                              alignment_score_thr,
+                                                                              mi_df,
+                                                                              add_others = add_others,
+                                                                              others_max_snps = others_max_snps,
+                                                                              others_rm_with_indels = others_rm_with_indels,
+                                                                              others_min_dist = others_min_dist,
+                                                                              others_max_close_snps = others_max_close_snps,
+                                                                              verbose = FALSE))
   stopCluster(clust)
 
   my_results_csv <- lapply(compare_results, "[[", 1)
@@ -368,6 +397,7 @@ loop_though_dartag_report <- function(report, botloci, hap_seq, n.cores=1, align
   rm_indels <- unlist(rm_indels)
   n_rm_others_indels  <- sum(sapply(compare_results, "[[", 5))
   n_rm_others_maxsnps <- sum(sapply(compare_results, "[[", 6))
+  n_rm_others_close_snps <- sum(sapply(compare_results, "[[", 7))
 
   vmsg("Number of tags removed because of low alignment score (threshold = %s): %s tags", verbose = verbose, level = 2, type = ">>", alignment_score_thr, length(rm_score))
   vmsg("Number of tags removed because of N in the alternative sequence: %s tags", verbose = verbose, level = 2, type = ">>", length(rm_N))
@@ -380,15 +410,18 @@ loop_though_dartag_report <- function(report, botloci, hap_seq, n.cores=1, align
   } else {
     vmsg("Number of tags removed because of indels as targets: 0 tags", verbose = verbose, level = 2, type = ">>")
   }
-  n_others_total  <- sum(sapply(compare_results, "[[", 7))
-  n_others_kept   <- n_others_total - n_rm_others_indels - n_rm_others_maxsnps
-  others_added_info <- unlist(lapply(compare_results, "[[", 8))
+  n_others_total  <- sum(sapply(compare_results, "[[", 8))
+  n_others_kept   <- n_others_total - n_rm_others_indels - n_rm_others_maxsnps - n_rm_others_close_snps
+  others_added_info <- unlist(lapply(compare_results, "[[", 9))
   if(add_others) {
     vmsg("Number of Other alleles found: %s (%s kept after filters, %s discarded)", verbose = verbose, level = 2, type = ">>", n_others_total, n_others_kept, n_others_total - n_others_kept)
     if(others_rm_with_indels)
       vmsg("Number of Other alleles discarded due to indels vs Ref: %s", verbose = verbose, level = 2, type = ">>", n_rm_others_indels)
     if(!is.null(others_max_snps))
       vmsg("Number of Other alleles discarded due to exceeding max SNPs (%s): %s", verbose = verbose, level = 2, type = ">>", others_max_snps, n_rm_others_maxsnps)
+    if(!is.null(others_max_close_snps))
+      vmsg("Number of Other alleles discarded due to more than %s SNPs with less than %s bp distant to each other: %s", verbose = verbose, level = 2, type = ">>", others_max_close_snps, others_min_dist, n_rm_others_close_snps)
+
     # if(length(others_added_info) > 0) {
     #   vmsg("Others tags added:", verbose = verbose, level = 3, type = ">>")
     #   for(msg in others_added_info) vmsg("  %s", verbose = verbose, level = 3, type = ">>", msg)
@@ -492,10 +525,20 @@ add_ref_alt <- function(one_tag, hap_seq, nsamples, verbose = TRUE) {
 #' @importFrom pwalign pairwiseAlignment nucleotideSubstitutionMatrix
 #'
 #' @noRd
-compare <- function(one_tag, botloci, alignment_score_thr = 40, mi_df = NULL, add_others = TRUE, others_max_snps = NULL, others_rm_with_indels = TRUE, verbose = FALSE){
+compare <- function(one_tag,
+                    botloci,
+                    alignment_score_thr = 40,
+                    mi_df = NULL,
+                    add_others = TRUE,
+                    others_max_snps = 5,
+                    others_rm_with_indels = TRUE,
+                    others_min_dist = 5,
+                    others_max_close_snps = 3,
+                    verbose = FALSE){
 
-  #idx <- which(names(updated_by_cloneID) == "Ra01_020534029")
+  #idx <- which(names(updated_by_cloneID) == "TA_1_7807815_1002_VariantMasked_000000166")
   #one_tag <- updated_by_cloneID[[idx]]
+
   cloneID <- one_tag$CloneID[1]
 
   isBotLoci <- cloneID %in% botloci[,1]
@@ -529,6 +572,7 @@ compare <- function(one_tag, botloci, alignment_score_thr = 40, mi_df = NULL, ad
                 rm_indels = NULL,
                 n_rm_others_indels = 0L,
                 n_rm_others_maxsnps = 0L,
+                n_rm_others_close_snps = 0L,
                 n_others_total = 0L,
                 others_added_info = character(0)))
   }
@@ -563,6 +607,7 @@ compare <- function(one_tag, botloci, alignment_score_thr = 40, mi_df = NULL, ad
                   rm_indels = cloneID,
                   n_rm_others_indels = 0L,
                   n_rm_others_maxsnps = 0L,
+                  n_rm_others_close_snps = 0L,
                   n_others_total = 0L,
                   others_added_info = character(0)))
     }
@@ -588,14 +633,14 @@ compare <- function(one_tag, botloci, alignment_score_thr = 40, mi_df = NULL, ad
           pos_ref_idx <- align@pattern@mismatch@unlistData
           rm_target <- which(pos_ref_idx == pos_target_idx)                 # remove target position when is AltMatch
           if(length(rm_target) >0) pos_ref_idx <- pos_ref_idx[-rm_target]
-          # Cases found where the AltMatch is another alternative for the target SNP - they are discarted
+          # Cases found where the AltMatch is another alternative for the target SNP - they are discarted, they should have be named Other
           if(length(pos_ref_idx) >0){
             ref_base_match <- substring(ref_seq, pos_ref_idx, pos_ref_idx)
             pos_alt_idx <- align@subject@mismatch@unlistData                 # If there are indels, the position in the alternative is not the same as the reference
             if(length(rm_target) >0) pos_alt_idx <- pos_alt_idx[-rm_target]   # remove target position when is AltMatch - but the order in the sequence is the same
             alt_base_match <- substring(Match_seq[j,]$AlleleSequence, pos_alt_idx, pos_alt_idx)
 
-            # If Match sequences have N, do not consider as polymorphism
+            # If Match sequences have N or IUPAC codes, do not consider the polymorphism
             if(any(!alt_base_match %in% c("A", "T", "C", "G"))) {
               ref_base_match <- ref_base_match[-which(!alt_base_match %in% c("A", "T", "C", "G"))]
               pos_ref_idx <- pos_ref_idx[-which(!alt_base_match %in% c("A", "T", "C", "G"))]
@@ -623,6 +668,7 @@ compare <- function(one_tag, botloci, alignment_score_thr = 40, mi_df = NULL, ad
       n_others_total <- nrow(others_seq)
       n_rm_others_indels <- 0L
       n_rm_others_maxsnps <- 0L
+      n_rm_others_close_snps <- 0L
       others_added_info <- character(0)
 
       if(add_others && nrow(others_seq) > 0){
@@ -644,6 +690,19 @@ compare <- function(one_tag, botloci, alignment_score_thr = 40, mi_df = NULL, ad
             n_rm_others_maxsnps <- n_rm_others_maxsnps + 1L
             next
           }
+
+          # Discard Others with SNPs too close to each other
+          ## Defined others_min_dist (default 5)
+          ## Defined others_max_close_snps (default 3)
+          if(!is.null(others_min_dist) &&
+             !is.null(others_max_close_snps) &&
+             any(diff(pos_ref_idx) < others_min_dist)) {
+            if(sum(diff(pos_ref_idx) < others_min_dist) > others_max_close_snps) {
+              n_rm_others_close_snps <- n_rm_others_close_snps + 1L
+              next
+            }
+          }
+
           rm_target_other <- which(pos_ref_idx == pos_target_idx)  # remove target position if base is the same as Ref or Alt
           if(length(rm_target_other) > 0) {
             other_tag_base <- substring(others_seq[j,]$AlleleSequence, pos_target_idx, pos_target_idx)
@@ -657,14 +716,22 @@ compare <- function(one_tag, botloci, alignment_score_thr = 40, mi_df = NULL, ad
             # Compute bases only when mismatch positions remain; substring() errors on integer(0) indices
             other_ref_base <- substring(ref_seq, pos_ref_idx, pos_ref_idx)
             other_alt_base <- substring(others_seq[j,]$AlleleSequence, pos_alt_idx, pos_alt_idx)
-            # If Match sequences have N, do not consider as polymorphism
+            # If Match sequences have IUPAC codes or N, do not consider as polymorphism
             if(any(!other_alt_base %in% c("A", "T", "C", "G"))) {
-              other_ref_base <- other_ref_base[-which(!other_alt_base %in% c("A", "T", "C", "G"))]
-              pos_ref_idx <- pos_ref_idx[-which(!other_alt_base %in% c("A", "T", "C", "G"))]
-              other_alt_base <- other_alt_base[-which(!other_alt_base %in% c("A", "T", "C", "G"))]
+              rm_pos <- which(!other_alt_base %in% c("A", "T", "C", "G"))
+              other_ref_base <- other_ref_base[-rm_pos]
+              pos_ref_idx <- pos_ref_idx[-rm_pos]
+              other_alt_base <- other_alt_base[-rm_pos]
+              # Check if the reference sequence doesn't have N or IUPAC codes
+              # all previous checks will let pass identical IUPAC codes between REF and ALT
+            } else if(any(!other_ref_base %in% c("A", "T", "C", "G"))){
+              rm_pos <- which(!other_ref_base %in% c("A", "T", "C", "G"))
+              other_ref_base <- other_ref_base[-rm_pos]
+              pos_ref_idx <- pos_ref_idx[-rm_pos]
+              other_alt_base <- other_alt_base[-rm_pos]
             }
 
-            if(length(other_alt_base) >0){ # If the N is the only polymorphis found, the Match tag will be discarted
+            if(length(other_alt_base) >0){ # If the N or IUPAC code is the only polymorphis found, the Match tag will be discarted
               # The reported position is always on reference
               pos <- pos_target - (pos_target_idx - pos_ref_idx)
 
@@ -690,6 +757,7 @@ compare <- function(one_tag, botloci, alignment_score_thr = 40, mi_df = NULL, ad
                   rm_indels = NULL,
                   n_rm_others_indels = n_rm_others_indels,
                   n_rm_others_maxsnps = n_rm_others_maxsnps,
+                  n_rm_others_close_snps = n_rm_others_close_snps,
                   n_others_total = n_others_total,
                   others_added_info = others_added_info))
     } else {
@@ -699,6 +767,7 @@ compare <- function(one_tag, botloci, alignment_score_thr = 40, mi_df = NULL, ad
                   rm_indels = NULL,
                   n_rm_others_indels = 0L,
                   n_rm_others_maxsnps = 0L,
+                  n_rm_others_close_snps = 0L,
                   n_others_total = 0L,
                   others_added_info = character(0)))
     }
@@ -709,6 +778,7 @@ compare <- function(one_tag, botloci, alignment_score_thr = 40, mi_df = NULL, ad
                 rm_indels = NULL,
                 n_rm_others_indels = 0L,
                 n_rm_others_maxsnps = 0L,
+                n_rm_others_close_snps = 0L,
                 n_others_total = 0L,
                 others_added_info = character(0)))
   }

--- a/R/madc2vcf_all.R
+++ b/R/madc2vcf_all.R
@@ -181,7 +181,7 @@ madc2vcf_all <- function(madc,
     id_col <- id_cols[which.max(match_n)]
     if(id_col != "CloneID" || !"CloneID" %in% colnames(mi_df)) {
       mi_df$CloneID <- mi_df[[id_col]]
-      if(id_col == "BI_markerID" | id_col == "Marker_ID") {
+      if(id_col == "BI_markerID" || id_col == "Marker_ID") {
         vmsg("markers_info: 'BI_markerID' or 'Marker_ID' column copied to 'CloneID' for internal use", verbose = verbose, level = 1)
       }
     }
@@ -640,15 +640,16 @@ compare <- function(one_tag,
             if(length(rm_target) >0) pos_alt_idx <- pos_alt_idx[-rm_target]   # remove target position when is AltMatch - but the order in the sequence is the same
             alt_base_match <- substring(Match_seq[j,]$AlleleSequence, pos_alt_idx, pos_alt_idx)
 
-            # If Match sequences have N or IUPAC codes, do not consider the polymorphism
-            if(any(!alt_base_match %in% c("A", "T", "C", "G"))) {
-              ref_base_match <- ref_base_match[-which(!alt_base_match %in% c("A", "T", "C", "G"))]
-              pos_ref_idx <- pos_ref_idx[-which(!alt_base_match %in% c("A", "T", "C", "G"))]
-              alt_base_match <- alt_base_match[-which(!alt_base_match %in% c("A", "T", "C", "G"))]
-            } else if(any(!ref_base_match %in% c("A", "T", "C", "G"))){
-              alt_base_match <- alt_base_match[-which(!ref_base_match %in% c("A", "T", "C", "G"))]
-              pos_ref_idx <- pos_ref_idx[-which(!ref_base_match %in% c("A", "T", "C", "G"))]
-              ref_base_match <- ref_base_match[-which(!ref_base_match %in% c("A", "T", "C", "G"))]
+            # If either base at a mismatch position is non-ATCG (IUPAC/N), do not
+            # consider it as a polymorphism. Filter positions where either the
+            # reference or the Match allele base is non-ATCG so that identical
+            # IUPAC codes allowed between REF/ALT don't surface as false SNPs.
+            rm_pos <- which(!alt_base_match %in% c("A", "T", "C", "G") |
+                              !ref_base_match %in% c("A", "T", "C", "G"))
+            if(length(rm_pos) > 0) {
+              ref_base_match <- ref_base_match[-rm_pos]
+              pos_ref_idx <- pos_ref_idx[-rm_pos]
+              alt_base_match <- alt_base_match[-rm_pos]
             }
 
             if(length(alt_base_match) >0){ # If the N is the only polymorphis found, the Match tag will be discarted
@@ -722,16 +723,13 @@ compare <- function(one_tag,
             # Compute bases only when mismatch positions remain; substring() errors on integer(0) indices
             other_ref_base <- substring(ref_seq, pos_ref_idx, pos_ref_idx)
             other_alt_base <- substring(others_seq[j,]$AlleleSequence, pos_alt_idx, pos_alt_idx)
-            # If Match sequences have IUPAC codes or N, do not consider as polymorphism
-            if(any(!other_alt_base %in% c("A", "T", "C", "G"))) {
-              rm_pos <- which(!other_alt_base %in% c("A", "T", "C", "G"))
-              other_ref_base <- other_ref_base[-rm_pos]
-              pos_ref_idx <- pos_ref_idx[-rm_pos]
-              other_alt_base <- other_alt_base[-rm_pos]
-              # Check if the reference sequence doesn't have N or IUPAC codes
-              # all previous checks will let pass identical IUPAC codes between REF and ALT
-            } else if(any(!other_ref_base %in% c("A", "T", "C", "G"))){
-              rm_pos <- which(!other_ref_base %in% c("A", "T", "C", "G"))
+            # If either base at a mismatch position is non-ATCG (IUPAC/N), do not
+            # consider it as a polymorphism. Filter positions where either the
+            # reference or the Other allele base is non-ATCG so that identical
+            # IUPAC codes allowed between REF/ALT don't surface as false SNPs.
+            rm_pos <- which(!other_alt_base %in% c("A", "T", "C", "G") |
+                              !other_ref_base %in% c("A", "T", "C", "G"))
+            if(length(rm_pos) > 0) {
               other_ref_base <- other_ref_base[-rm_pos]
               pos_ref_idx <- pos_ref_idx[-rm_pos]
               other_alt_base <- other_alt_base[-rm_pos]

--- a/R/madc2vcf_all.R
+++ b/R/madc2vcf_all.R
@@ -15,7 +15,7 @@
 #' @param add_others A logical value. If TRUE, alleles labeled "Other" in the MADC file are included in off-target SNP extraction. Default is TRUE.
 #' @param others_max_snps An integer or NULL. If not NULL, Other alleles with more than this many SNP differences versus the Ref sequence (as detected by pairwise alignment) are discarded. Default is 5.
 #' @param others_rm_with_indels A logical value. If TRUE, Other alleles that contain insertions or deletions relative to the Ref sequence (as detected by pairwise alignment) are discarded. Default is TRUE.
-#' @param others_min_dist An integer specifying the minimum distance (in base pairs) between SNPs in Other alleles. Default is 5.
+#' @param others_min_dist An integer or NULL. If not NULL, Other alleles with SNPs that are closer than this many base pairs to each other are discarded. Default is 5.
 #' @param others_max_close_snps An integer or NULL. If not NULL, Other alleles with more than this many SNPs that are closer than `others_min_dist` base pairs to each other are discarded. Default is 3.
 #' @param verbose A logical value indicating whether to print metrics and progress to the console. Default is TRUE.
 #'
@@ -105,6 +105,8 @@ madc2vcf_all <- function(madc,
   vmsg("add_others        : %s", verbose = verbose, level = 1, type = ">>", add_others)
   vmsg("others_max_snps   : %s", verbose = verbose, level = 1, type = ">>", if (is.null(others_max_snps)) "NULL" else others_max_snps)
   vmsg("others_rm_with_indels     : %s", verbose = verbose, level = 1, type = ">>", others_rm_with_indels)
+  vmsg("others_min_dist   : %s", verbose = verbose, level = 1, type = ">>", if (is.null(others_min_dist)) "NULL" else others_min_dist)
+  vmsg("others_max_close_snps      : %s", verbose = verbose, level = 1, type = ">>", if (is.null(others_max_close_snps)) "NULL" else others_max_close_snps)
   vmsg("out_vcf           : %s", verbose = verbose, level = 1, type = ">>", if (is.null(out_vcf)) "NULL" else out_vcf)
   vmsg("Checking inputs", verbose = verbose, level = 0, type = ">>")
 
@@ -129,6 +131,8 @@ madc2vcf_all <- function(madc,
   if(!is.logical(add_others)) stop("add_others should be logical.")
   if(!is.null(others_max_snps) && (!is.numeric(others_max_snps) || others_max_snps < 1)) stop("others_max_snps should be a positive integer or NULL.")
   if(!is.logical(others_rm_with_indels)) stop("others_rm_with_indels should be logical.")
+  if(!is.null(others_min_dist) && (!is.numeric(others_min_dist) || others_min_dist < 1)) stop("others_min_dist should be a positive integer or NULL.")
+  if(!is.null(others_max_close_snps) && (!is.numeric(others_max_close_snps) || others_max_close_snps < 1)) stop("others_max_close_snps should be a positive integer or NULL.")
   if(!is.logical(verbose)) stop("verbose should be logical.")
 
   bigr_meta <- paste0('##BIGrCommandLine.madc2vcf_all=<ID=madc2vcf_all,Version="',
@@ -633,7 +637,7 @@ compare <- function(one_tag,
           pos_ref_idx <- align@pattern@mismatch@unlistData
           rm_target <- which(pos_ref_idx == pos_target_idx)                 # remove target position when is AltMatch
           if(length(rm_target) >0) pos_ref_idx <- pos_ref_idx[-rm_target]
-          # Cases found where the AltMatch is another alternative for the target SNP - they are discarted, they should have be named Other
+          # Cases found where the AltMatch is another alternative for the target SNP - they are discarded, they should have been listed as Other
           if(length(pos_ref_idx) >0){
             ref_base_match <- substring(ref_seq, pos_ref_idx, pos_ref_idx)
             pos_alt_idx <- align@subject@mismatch@unlistData                 # If there are indels, the position in the alternative is not the same as the reference

--- a/R/madc2vcf_all.R
+++ b/R/madc2vcf_all.R
@@ -11,7 +11,7 @@
 #' @param alignment_score_thr A numeric value specifying the minimum alignment score threshold. Default is 40.
 #' @param n.cores An integer specifying the number of cores to use for parallel processing. Default is 1.
 #' @param out_vcf A string specifying the name of the output VCF file. If the file extension is not `.vcf`, it will be appended automatically.
-#' @param markers_info A string specifying the path to a CSV file with marker information (CloneID/BI_markerID, Chr, Pos, Ref, Alt, Type, Indel_pos columns as needed).
+#' @param markers_info A string specifying the path to a CSV file with marker information (CloneID/Marker_ID/BI_markerID, Chr, Pos, Ref, Alt, Type, Indel_pos columns as needed).
 #' @param add_others A logical value. If TRUE, alleles labeled "Other" in the MADC file are included in off-target SNP extraction. Default is TRUE.
 #' @param others_max_snps An integer or NULL. If not NULL, Other alleles with more than this many SNP differences versus the Ref sequence (as detected by pairwise alignment) are discarded. Default is 5.
 #' @param others_rm_with_indels A logical value. If TRUE, Other alleles that contain insertions or deletions relative to the Ref sequence (as detected by pairwise alignment) are discarded. Default is TRUE.
@@ -170,13 +170,13 @@ madc2vcf_all <- function(madc,
     mi_df <- read.csv(markers_info)
     id_cols <- intersect(c("CloneID", "BI_markerID","Marker_ID"), colnames(mi_df))
     if(!length(id_cols)) {
-      stop("markers_info must contain a marker ID column named either 'CloneID' or 'BI_markerID'.")
+      stop("markers_info must contain a marker ID column named either 'CloneID', 'Marker_ID', or 'BI_markerID'.")
     }
     match_n <- vapply(id_cols, function(col) {
       sum(unique(report$CloneID) %in% unique(stats::na.omit(mi_df[[col]])))
     }, integer(1))
     if(!any(match_n)) {
-      stop("None of the markers_info CloneID or BI_markerID values match the MADC CloneID column. Please make sure they use the same marker IDs.")
+      stop("None of the markers_info CloneID, Marker_ID, or BI_markerID values match the MADC CloneID column. Please make sure they use the same marker IDs.")
     }
     id_col <- id_cols[which.max(match_n)]
     if(id_col != "CloneID" || !"CloneID" %in% colnames(mi_df)) {
@@ -645,6 +645,10 @@ compare <- function(one_tag,
               ref_base_match <- ref_base_match[-which(!alt_base_match %in% c("A", "T", "C", "G"))]
               pos_ref_idx <- pos_ref_idx[-which(!alt_base_match %in% c("A", "T", "C", "G"))]
               alt_base_match <- alt_base_match[-which(!alt_base_match %in% c("A", "T", "C", "G"))]
+            } else if(any(!ref_base_match %in% c("A", "T", "C", "G"))){
+              alt_base_match <- alt_base_match[-which(!ref_base_match %in% c("A", "T", "C", "G"))]
+              pos_ref_idx <- pos_ref_idx[-which(!ref_base_match %in% c("A", "T", "C", "G"))]
+              ref_base_match <- ref_base_match[-which(!ref_base_match %in% c("A", "T", "C", "G"))]
             }
 
             if(length(alt_base_match) >0){ # If the N is the only polymorphis found, the Match tag will be discarted
@@ -697,7 +701,9 @@ compare <- function(one_tag,
           if(!is.null(others_min_dist) &&
              !is.null(others_max_close_snps) &&
              any(diff(pos_ref_idx) < others_min_dist)) {
-            if(sum(diff(pos_ref_idx) < others_min_dist) > others_max_close_snps) {
+            gaps_close <- diff(pos_ref_idx) < others_min_dist
+            snp_is_close <- c(gaps_close, FALSE) | c(FALSE, gaps_close)
+            if(sum(snp_is_close) > others_max_close_snps) {
               n_rm_others_close_snps <- n_rm_others_close_snps + 1L
               next
             }

--- a/R/madc2vcf_multi.R
+++ b/R/madc2vcf_multi.R
@@ -100,7 +100,7 @@ madc2vcf_multi <- function(madc_file,
   if (!isTRUE(checks$checks["ChromPos"])) {
     if (is.null(markers_info))
       stop("CloneID column does not follow the 'Chr_Pos' format. ",
-           "Please provide a markers_info file with at least 'CloneID'/'BI_markerID', ",
+           "Please provide a markers_info file with at least 'CloneID'/'Marker_ID'/'BI_markerID', ",
            "'Chr', and 'Pos' columns.")
     if (!all(c("Chr", "Pos") %in% colnames(mi_df)))
       stop("CloneID column does not follow the 'Chr_Pos' format. ",

--- a/R/madc2vcf_multi.R
+++ b/R/madc2vcf_multi.R
@@ -89,7 +89,7 @@ madc2vcf_multi <- function(madc_file,
     stop("The MADC file is missing required columns (CloneID, AlleleID, AlleleSequence)")
 
   if (checks$checks["IUPACcodes"])
-    stop("MADC Allele Sequences contain IUPAC (non-ATCG) codes. Please run HapApp to clean MADC file before using this function.")
+    stop("MADC Allele Sequences contain different IUPAC (non-ATCG) codes in REF and ALT sequences. Please run HapApp to clean MADC file before using this function.")
 
   if (!isTRUE(checks$checks["RefAltSeqs"]))
     stop("Not all Ref sequences have a corresponding Alt or vice versa. Please provide a complete MADC file before using this function.")

--- a/man/check_madc_sanity.Rd
+++ b/man/check_madc_sanity.Rd
@@ -61,7 +61,7 @@ or a \code{"-"} character is present in \code{AlleleSequence};
 \item \strong{allNArow} - at least one row contains only \code{NA} or empty values;
 \item \strong{RefAltSeqs} - every \code{CloneID} has at least one \code{Ref} and one \code{Alt} allele row;
 \item \strong{OtherAlleles} - presence of alleles where the target locus differs from both the Ref and Alt in \code{AlleleSequence};
-\item \strong{IUPACcodes_MatchAlleles} - presence of non-ATCG characters in \code{AlleleSequence} for RefMatch_/AltMatch_ alleles.
+\item \strong{IUPACcodes_MatchAlleles} - presence of non-ATCG characters in \code{AlleleSequence} for RefMatch_/AltMatch_/Other alleles.
 }
 }
 \details{
@@ -78,7 +78,7 @@ any CloneID has IUPAC codes at different positions between Ref and Alt, or
 IUPAC is present in only one of them. \code{IUPACcodes_IdenticalRefAlt} is \code{TRUE}
 when any CloneID has Ref and Alt with IUPAC codes at exactly the same positions
 (non-IUPAC bases may still differ). Those CloneIDs are stored in
-\code{iupac_identical_clone_ids}. RefMatch_/AltMatch_ alleles are checked
+\code{iupac_identical_clone_ids}. RefMatch_/AltMatch_/Other alleles are checked
 separately via \code{IUPACcodes_MatchAlleles}.
 \item \strong{Indels:} Rows are split by \code{AlleleID} containing \code{"Ref_0001"} vs
 \code{"Alt_0002"}, merged by \code{CloneID}, and flagged as indels if either (a) the

--- a/man/check_madc_sanity.Rd
+++ b/man/check_madc_sanity.Rd
@@ -14,11 +14,12 @@ If \code{FixAlleleIDs} is \code{FALSE} (raw DArT format), the first 7 rows are
 treated as header filler and skipped before further checks are run.}
 }
 \value{
-A named list with five elements:
+A named list with six elements:
 \describe{
-\item{checks}{Named logical vector with nine entries:
-\code{Columns}, \code{FixAlleleIDs}, \code{IUPACcodes}, \code{LowerCase}, \code{Indels},
-\code{ChromPos}, \code{allNAcol}, \code{allNArow}, \code{RefAltSeqs}.
+\item{checks}{Named logical vector with twelve entries:
+\code{Columns}, \code{FixAlleleIDs}, \code{IUPACcodes}, \code{IUPACcodes_IdenticalRefAlt},
+\code{LowerCase}, \code{Indels}, \code{ChromPos}, \code{allNAcol}, \code{allNArow}, \code{RefAltSeqs},
+\code{OtherAlleles}, \code{IUPACcodes_MatchAlleles}.
 \code{TRUE} means the condition was detected (or passed for \code{Columns},
 \code{FixAlleleIDs}, \code{ChromPos}, and \code{RefAltSeqs}); \code{NA} means the check
 was skipped.}
@@ -28,6 +29,11 @@ when it is \code{FALSE}. Indexed by the same names as \code{checks}.}
 \item{indel_clone_ids}{Character vector of \code{CloneID}s where ref/alt
 lengths differ. Returns \code{character(0)} if none are found, or \code{NULL}
 when required columns are missing.}
+\item{iupac_identical_clone_ids}{Character vector of \code{CloneID}s where
+Ref and Alt alleles have IUPAC codes at the same positions in their
+sequences (the sequences may differ at standard ATCG positions). Returns
+\code{character(0)} if none are found, or \code{NULL} when required columns are
+missing.}
 \item{missRef}{Character vector of \code{CloneID}s that have no \code{Ref} allele
 row. Returns \code{character(0)} if all \code{CloneID}s have a \code{Ref} row, or
 \code{NULL} when required columns are missing.}
@@ -37,12 +43,15 @@ row. Returns \code{character(0)} if all \code{CloneID}s have an \code{Alt} row, 
 }
 }
 \description{
-Performs nine quick validations on an allele report:
+Performs twelve quick validations on an allele report:
 \enumerate{
 \item \strong{Columns} - required columns are present (\code{CloneID}, \code{AlleleID}, \code{AlleleSequence});
 \item \strong{FixAlleleIDs} - first column's first up-to-6 rows are not all blank or \code{"*"}
 \emph{and} both \verb{_0001} and \verb{_0002} appear in \code{AlleleID};
-\item \strong{IUPACcodes} - presence of non-ATCG characters in \code{AlleleSequence};
+\item \strong{IUPACcodes} - presence of non-ATCG characters in Ref_/Alt_ \code{AlleleSequence}
+that differ in position between Ref and Alt, or are present in only one;
+\item \strong{IUPACcodes_IdenticalRefAlt} - presence of Ref_/Alt_ pairs that share IUPAC codes
+at the same positions in their sequences;
 \item \strong{LowerCase} - presence of lowercase a/t/c/g in \code{AlleleSequence};
 \item \strong{Indels} - reference/alternate allele lengths differ for the same \code{CloneID},
 or a \code{"-"} character is present in \code{AlleleSequence};
@@ -51,7 +60,8 @@ or a \code{"-"} character is present in \code{AlleleSequence};
 \item \strong{allNAcol} - at least one column contains only \code{NA} or empty values;
 \item \strong{allNArow} - at least one row contains only \code{NA} or empty values;
 \item \strong{RefAltSeqs} - every \code{CloneID} has at least one \code{Ref} and one \code{Alt} allele row;
-\item \strong{OtherAlleles} - presence of alleles where the target locus differs from both the Ref and Alt in \code{AlleleSequence}.
+\item \strong{OtherAlleles} - presence of alleles where the target locus differs from both the Ref and Alt in \code{AlleleSequence};
+\item \strong{IUPACcodes_MatchAlleles} - presence of non-ATCG characters in \code{AlleleSequence} for RefMatch_/AltMatch_ alleles.
 }
 }
 \details{
@@ -63,6 +73,13 @@ first 7 rows are dropped before subsequent checks are run. The check is
 \verb{_0001}/\verb{_0002} suffixes).
 \item \strong{IUPAC check:} Flags any character outside \code{A}, \code{T}, \code{C}, \code{G} and \code{"-"}
 (case-insensitive), which includes ambiguity codes (\code{N}, \code{R}, \code{Y}, etc.).
+For Ref_/Alt_ alleles, two checks are performed: \code{IUPACcodes} is \code{TRUE} when
+any CloneID has IUPAC codes at different positions between Ref and Alt, or
+IUPAC is present in only one of them. \code{IUPACcodes_IdenticalRefAlt} is \code{TRUE}
+when any CloneID has Ref and Alt with IUPAC codes at exactly the same positions
+(non-IUPAC bases may still differ). Those CloneIDs are stored in
+\code{iupac_identical_clone_ids}. RefMatch_/AltMatch_ alleles are checked
+separately via \code{IUPACcodes_MatchAlleles}.
 \item \strong{Indels:} Rows are split by \code{AlleleID} containing \code{"Ref_0001"} vs
 \code{"Alt_0002"}, merged by \code{CloneID}, and flagged as indels if either (a) the
 lengths of \code{AlleleSequence} differ, (b) the sequences have the same length

--- a/man/madc2vcf_all.Rd
+++ b/man/madc2vcf_all.Rd
@@ -18,6 +18,8 @@ madc2vcf_all(
   add_others = TRUE,
   others_max_snps = 5,
   others_rm_with_indels = TRUE,
+  others_min_dist = 5,
+  others_max_close_snps = 3,
   verbose = TRUE
 )
 }
@@ -44,9 +46,13 @@ madc2vcf_all(
 
 \item{add_others}{A logical value. If TRUE, alleles labeled "Other" in the MADC file are included in off-target SNP extraction. Default is TRUE.}
 
-\item{others_max_snps}{An integer or NULL. If not NULL, Other alleles with more than this many SNP differences versus the Ref sequence (as detected by pairwise alignment) are discarded. Default is NULL (no limit).}
+\item{others_max_snps}{An integer or NULL. If not NULL, Other alleles with more than this many SNP differences versus the Ref sequence (as detected by pairwise alignment) are discarded. Default is 5.}
 
 \item{others_rm_with_indels}{A logical value. If TRUE, Other alleles that contain insertions or deletions relative to the Ref sequence (as detected by pairwise alignment) are discarded. Default is TRUE.}
+
+\item{others_min_dist}{An integer specifying the minimum distance (in base pairs) between SNPs in Other alleles. Default is 5.}
+
+\item{others_max_close_snps}{An integer or NULL. If not NULL, Other alleles with more than this many SNPs that are closer than \code{others_min_dist} base pairs to each other are discarded. Default is 3.}
 
 \item{verbose}{A logical value indicating whether to print metrics and progress to the console. Default is TRUE.}
 }

--- a/man/madc2vcf_all.Rd
+++ b/man/madc2vcf_all.Rd
@@ -50,7 +50,7 @@ madc2vcf_all(
 
 \item{others_rm_with_indels}{A logical value. If TRUE, Other alleles that contain insertions or deletions relative to the Ref sequence (as detected by pairwise alignment) are discarded. Default is TRUE.}
 
-\item{others_min_dist}{An integer specifying the minimum distance (in base pairs) between SNPs in Other alleles. Default is 5.}
+\item{others_min_dist}{An integer or NULL. If not NULL, Other alleles with SNPs that are closer than this many base pairs to each other are discarded. Default is 5.}
 
 \item{others_max_close_snps}{An integer or NULL. If not NULL, Other alleles with more than this many SNPs that are closer than \code{others_min_dist} base pairs to each other are discarded. Default is 3.}
 

--- a/man/madc2vcf_all.Rd
+++ b/man/madc2vcf_all.Rd
@@ -42,7 +42,7 @@ madc2vcf_all(
 
 \item{out_vcf}{A string specifying the name of the output VCF file. If the file extension is not \code{.vcf}, it will be appended automatically.}
 
-\item{markers_info}{A string specifying the path to a CSV file with marker information (CloneID/BI_markerID, Chr, Pos, Ref, Alt, Type, Indel_pos columns as needed).}
+\item{markers_info}{A string specifying the path to a CSV file with marker information (CloneID/Marker_ID/BI_markerID, Chr, Pos, Ref, Alt, Type, Indel_pos columns as needed).}
 
 \item{add_others}{A logical value. If TRUE, alleles labeled "Other" in the MADC file are included in off-target SNP extraction. Default is TRUE.}
 

--- a/tests/testthat/test-check_madc_sanity.R
+++ b/tests/testthat/test-check_madc_sanity.R
@@ -2,13 +2,15 @@ test_that("check madc",{
   skip_if_offline("raw.githubusercontent.com")
 
   github_path <- "https://raw.githubusercontent.com/Breeding-Insight/BIGapp-PanelHub/refs/heads/long_seq/test_madcs/"
-  names <- c("Columns", "FixAlleleIDs", "IUPACcodes", "LowerCase", "Indels", "ChromPos", "allNAcol", "allNArow", "RefAltSeqs", "OtherAlleles")
+  names <- c("Columns", "FixAlleleIDs", "IUPACcodes", "IUPACcodes_IdenticalRefAlt",
+             "LowerCase", "Indels", "ChromPos", "allNAcol", "allNArow",
+             "RefAltSeqs", "OtherAlleles", "IUPACcodes_MatchAlleles")
 
   # raw madc
   report <- read.csv(paste0(github_path,"/alfalfa_madc_raw.csv"))
 
   res <- check_madc_sanity(report)
-  exp <- c(TRUE, FALSE, FALSE, FALSE, FALSE, TRUE, TRUE, FALSE, TRUE, FALSE)
+  exp <- c(TRUE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, TRUE, FALSE, TRUE, FALSE, FALSE)
   names(exp) <- names
   expect_equal(res$checks, exp)
 
@@ -16,7 +18,7 @@ test_that("check madc",{
   report <- read.csv(paste0(github_path,"/alfalfa_lowercase.csv"))
 
   res <- check_madc_sanity(report)
-  exp <- c(TRUE, TRUE, FALSE, TRUE, FALSE, TRUE, FALSE, FALSE, FALSE, FALSE)
+  exp <- c(TRUE, TRUE, FALSE, FALSE, TRUE, FALSE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE)
   names(exp) <- names
   expect_equal(res$checks, exp)
 
@@ -24,7 +26,7 @@ test_that("check madc",{
   report <- read.csv(paste0(github_path,"/alfalfa_IUPAC.csv"))
 
   res <- check_madc_sanity(report)
-  exp <- c(TRUE, TRUE, TRUE, FALSE, FALSE, TRUE, FALSE, FALSE,TRUE, FALSE)
+  exp <- c(TRUE, TRUE, TRUE, FALSE,FALSE, FALSE, TRUE, FALSE, FALSE,TRUE, FALSE,TRUE)
   names(exp) <- names
   expect_equal(res$checks, exp)
 
@@ -32,7 +34,7 @@ test_that("check madc",{
   report <- read.csv(paste0(github_path,"/alfalfa_madc.csv"))
 
   res <- check_madc_sanity(report)
-  exp <- c(TRUE, TRUE, FALSE, FALSE, FALSE, TRUE, FALSE, FALSE,TRUE, FALSE)
+  exp <- c(TRUE, TRUE, FALSE, FALSE,FALSE, FALSE, TRUE, FALSE, FALSE,TRUE, FALSE, FALSE)
   names(exp) <- names
   expect_equal(res$checks, exp)
 
@@ -40,7 +42,7 @@ test_that("check madc",{
   report <- read.csv(paste0(github_path,"/potato_indel_madc.csv"))
 
   res <- check_madc_sanity(report)
-  exp <- c(TRUE, TRUE, FALSE, FALSE, TRUE, FALSE, FALSE, FALSE,TRUE, FALSE)
+  exp <- c(TRUE, TRUE, FALSE, FALSE, FALSE, TRUE, FALSE, FALSE, FALSE,TRUE, FALSE, FALSE)
   names(exp) <- names
   expect_equal(res$checks, exp)
 
@@ -48,7 +50,7 @@ test_that("check madc",{
   report <- read.csv(paste0(github_path,"/potato_indel_IUPAC.csv"))
 
   res <- check_madc_sanity(report)
-  exp <- c(TRUE, TRUE, TRUE, FALSE, TRUE, FALSE, FALSE, FALSE,TRUE, FALSE)
+  exp <- c(TRUE, TRUE, TRUE, FALSE,FALSE, TRUE, FALSE, FALSE, FALSE,TRUE, FALSE,TRUE)
   names(exp) <- names
   expect_equal(res$checks, exp)
 
@@ -56,7 +58,7 @@ test_that("check madc",{
   report <- read.csv(paste0(github_path,"/potato_indel_lowercase.csv"))
 
   res <- check_madc_sanity(report)
-  exp <- c(TRUE, TRUE, FALSE, TRUE, TRUE, FALSE, FALSE, FALSE,TRUE, FALSE)
+  exp <- c(TRUE, TRUE, FALSE, FALSE, TRUE, TRUE, FALSE, FALSE, FALSE,TRUE, FALSE, FALSE)
   names(exp) <- names
   expect_equal(res$checks, exp)
 
@@ -64,7 +66,7 @@ test_that("check madc",{
   report <- read.csv(paste0(github_path,"/potato_more_indels_madc_ChromPosFALSE.csv"))
 
   res <- check_madc_sanity(report)
-  exp <- c(TRUE, TRUE, FALSE, FALSE, TRUE, FALSE, FALSE, FALSE,TRUE, FALSE)
+  exp <- c(TRUE, TRUE, FALSE, FALSE, FALSE, TRUE, FALSE, FALSE, FALSE,TRUE, FALSE, FALSE)
   names(exp) <- names
   expect_equal(res$checks, exp)
 })

--- a/tests/testthat/test-madc2vcf_all.R
+++ b/tests/testthat/test-madc2vcf_all.R
@@ -285,7 +285,7 @@ test_that("simu alfalfa",{
                    markers_info = alfalfa_markers_info,
                    out_vcf = out,
                    verbose = FALSE),
-      regexp = "None of the markers_info CloneID( or BI_markerID)? values match the MADC CloneID column. Please make sure they use the same marker IDs."
+      regexp = "None of the markers_info CloneID, Marker_ID, or BI_markerID values match the MADC CloneID column. Please make sure they use the same marker IDs."
     )
 
     # Test error when markers_info_ChromPos is provided but IDs still don't match botloci

--- a/tests/testthat/test-madc2vcf_all.R
+++ b/tests/testthat/test-madc2vcf_all.R
@@ -48,15 +48,15 @@ test_that("test madc offtargets",{
 
   # Without hap_seq provided
   set.seed(123)
-  madc2vcf_all(madc = madc_file,
-               botloci_file = bot_file,
-               hap_seq_file = NULL,
-               n.cores = 2,
-               rm_multiallelic_SNP = FALSE,
-               multiallelic_SNP_dp_thr = 0,
-               multiallelic_SNP_sample_thr = 0,
-               out_vcf = temp,
-               verbose = FALSE)
+  expect_warning(madc2vcf_all(madc = madc_file,
+                              botloci_file = bot_file,
+                              hap_seq_file = NULL,
+                              n.cores = 2,
+                              rm_multiallelic_SNP = FALSE,
+                              multiallelic_SNP_dp_thr = 0,
+                              multiallelic_SNP_sample_thr = 0,
+                              out_vcf = temp,
+                              verbose = FALSE))
 
   vcf <- read.vcfR(temp)
 
@@ -336,12 +336,12 @@ test_that("simu alfalfa",{
     expect_equal(sum(dp[1,]), 4534)
     expect_equal(sum(dp[,5]), 233719)
 
-    madc2vcf_all(madc = alfalfa_lowercase,
-                 botloci_file = alfalfa_botloci,
-                 hap_seq_file = NULL,
-                 n.cores = 1,
-                 out_vcf = out,
-                 verbose = FALSE)
+    expect_warning(madc2vcf_all(madc = alfalfa_lowercase,
+                                botloci_file = alfalfa_botloci,
+                                hap_seq_file = NULL,
+                                n.cores = 1,
+                                out_vcf = out,
+                                verbose = FALSE))
 
     vcf <- read.vcfR(out, verbose = FALSE)
     lut <- read.csv(alfalfa_markers_info)
@@ -356,13 +356,13 @@ test_that("simu alfalfa",{
     expect_equal(sum(dp[1,]), 4534)
     expect_equal(sum(dp[,5]), 230415)
 
-    madc2vcf_all(madc = alfalfa_lowercase,
-                 botloci_file = alfalfa_botloci,
-                 hap_seq_file = NULL,
-                 n.cores = 1,
-                 markers_info = alfalfa_markers_info,
-                 out_vcf = out,
-                 verbose = FALSE)
+    expect_warning(madc2vcf_all(madc = alfalfa_lowercase,
+                                botloci_file = alfalfa_botloci,
+                                hap_seq_file = NULL,
+                                n.cores = 1,
+                                markers_info = alfalfa_markers_info,
+                                out_vcf = out,
+                                verbose = FALSE))
 
     vcf <- read.vcfR(out, verbose = FALSE)
     lut <- read.csv(alfalfa_markers_info)
@@ -389,7 +389,7 @@ test_that("simu alfalfa",{
                    n.cores = 1,
                    out_vcf = out,
                    verbose = FALSE),
-      regexp = "IUPAC \\(non-ATCG\\) codes found in AlleleSequence\\. This codes are not currently supported by BIGr/BIGapp\\. Run HapApp to replace them"
+      regexp = "IUPAC \\(non-ATCG\\) codes found in Ref_/Alt_ AlleleSequence that differ between alleles or are present in only one. These codes are not currently supported by BIGr/BIGapp"
     )
   })
 
@@ -576,7 +576,7 @@ test_that("simu alfalfa",{
                    markers_info = potato_markers_info,
                    out_vcf = out,
                    verbose = FALSE),
-      regexp = "IUPAC \\(non-ATCG\\) codes found in AlleleSequence. This codes are not currently supported by BIGr/BIGapp. Run HapApp to replace them"
+      regexp = "IUPAC \\(non-ATCG\\) codes found in Ref_/Alt_ AlleleSequence that differ between alleles or are present in only one. These codes are not currently supported by BIGr/BIGapp"
     )
   })
 

--- a/tests/testthat/test-madc2vcf_multi.R
+++ b/tests/testthat/test-madc2vcf_multi.R
@@ -114,7 +114,7 @@ test_that("madc2vcf_multi — alfalfa (BIGapp-PanelHub)", {
       outfile      = out,
       ploidy       = 4L,
       verbose      = TRUE
-    ), regexp = "MADC Allele Sequences contain IUPAC \\(non-ATCG\\) codes. Please run HapApp to clean MADC file before using this function."
+    ), regexp = "MADC Allele Sequences contain different IUPAC \\(non-ATCG\\) codes in REF and ALT sequences. Please run HapApp to clean MADC file before using this function."
   )
 
   out <- tempfile(fileext = ".vcf")


### PR DESCRIPTION
HapApp pipelines only replaces IUPAC codes present in the Ref and Alt alleles. IUPAC codes present in Match alleles should be ignored by the BIGr SNP calling algorithms.

- [x] Decide if Ref and Alt with same IUPAC code should be kept or not. Example:

```
"AAGAAGTCAACCAGGC[R]CAAACCCAACCAAGCCTCCTTTTGGACTTCGAGGATTAAAGTACAGAACAAAATTTTGGCCTGGAACATTTTCAGCAGGTACTGATGCTCCT"
"AAGAAGTCAACCAGGC[R]CAAACCCAACCACGCCTCCTTTTGGACTTCGAGGATTAAAGTACAGAACAAAATTTTGGCCTGGAACATTTTCAGCAGGTACTGATGCTCCT"
```

- [X] Change check MADC to distinguish Ref/Alt IUPAC from Match IUPAC
- [x] Change madc2vcf_all to ignore IUPAC codes
